### PR TITLE
Persist cheat threads and streamline config access

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -6,6 +6,7 @@
 #include <mithril/types.hpp>
 #include <unordered_map>
 #include <vector>
+#include <atomic>
 
 #include "colors.hpp"
 #include "key_code.hpp"
@@ -249,7 +250,7 @@ struct Config {
 };
 
 struct Flags {
-    bool should_quit = false;
+    std::atomic<bool> should_quit {false};
     // whether or not to read memory from file or via process_vm_readv
     bool file_mem = false;
     bool no_visuals = false;

--- a/include/globals.hpp
+++ b/include/globals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <shared_mutex>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -7,7 +8,7 @@
 #include "config.hpp"
 #include "cs2/info.hpp"
 
-extern std::mutex config_lock;
+extern std::shared_mutex config_lock;
 extern std::string current_config;
 extern std::vector<std::string> available_configs;
 extern Config config;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -1,12 +1,13 @@
 #include <glm/glm.hpp>
 #include <mithril/logging.hpp>
+#include <shared_mutex>
 #include <mutex>
 #include <vector>
 
 #include "config.hpp"
 #include "cs2/info.hpp"
 
-std::mutex config_lock;
+std::shared_mutex config_lock;
 std::string current_config = "deadlocked.toml";
 std::vector<std::string> available_configs = ListConfigs();
 Config config = LoadConfig(current_config);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -341,20 +341,21 @@ void Gui() {
         ImGui::EndChild();
 
         // tabs
-        config_lock.lock();
+        {
+            std::unique_lock<std::shared_mutex> cfg_guard(config_lock);
 
-        ImGui::SetCursorPos({sizes.sidebar_width + sizes.spacing, sizes.top_bar_height + 12.0f});
-        const ImVec2 available_main = ImGui::GetContentRegionAvail();
+            ImGui::SetCursorPos({sizes.sidebar_width + sizes.spacing, sizes.top_bar_height + 12.0f});
+            const ImVec2 available_main = ImGui::GetContentRegionAvail();
 
-        const ImVec2 col_size = {
-            (available_main.x - sizes.spacing * 2.0f) / 2, available_main.y - 16.0f};
-        const ImVec2 current_pos = ImGui::GetCursorPos();
-        ImGui::SetNextWindowPos({current_pos.x + 10.0f, current_pos.y + 15.0f});
+            const ImVec2 col_size = {
+                (available_main.x - sizes.spacing * 2.0f) / 2, available_main.y - 16.0f};
+            const ImVec2 current_pos = ImGui::GetCursorPos();
+            ImGui::SetNextWindowPos({current_pos.x + 10.0f, current_pos.y + 15.0f});
 
-        if (active_tab == Tab::Aimbot) {
-            ImGui::BeginChild(
-                "Aimbot", col_size, ImGuiChildFlags_AlwaysUseWindowPadding,
-                ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
+            if (active_tab == Tab::Aimbot) {
+                ImGui::BeginChild(
+                    "Aimbot", col_size, ImGuiChildFlags_AlwaysUseWindowPadding,
+                    ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
 
             if (aimbot_global) {
                 Title("Aimbot (Global)");
@@ -1148,7 +1149,7 @@ void Gui() {
         }
 
         ImGui::End();
-        config_lock.unlock();
+        }
 
         ImGui::Render();
         glm::ivec2 overlay_vp_size;
@@ -1171,9 +1172,7 @@ void Gui() {
 
     logging::Info("shutting down...");
 
-    config_lock.lock();
     flags.should_quit = true;
-    config_lock.unlock();
     cs2.join();
 
     ImGui::SetCurrentContext(gui_ctx);


### PR DESCRIPTION
## Summary
- Keep FovChanger, NoFlash, Rcs, Smokes, Aimbot, and Triggerbot running in dedicated threads guarded by a shared config lock
- Replace `config_lock` with `std::shared_mutex` and make quit flag atomic to avoid excessive config lock cycling
- Use RAII locking in GUI and drop redundant locking when signaling shutdown

## Testing
- `./build.sh` *(fails: The source directory `/workspace/deadlocked/lib/glm` does not contain a CMakeLists.txt file.)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc64b6e4832dba792fc431cc641c